### PR TITLE
Add music album class with methods

### DIFF
--- a/music_album.rb
+++ b/music_album.rb
@@ -1,0 +1,13 @@
+require_relative './item'
+class MusicAlbum < Item
+  attr_accessor :on_spotify
+
+  def initialize(on_spotify: true)
+    super()
+    @on_spotify = on_spotify
+  end
+
+  def can_be_archived?
+    @publish_date > 10 && @on_spotify = true
+  end
+end


### PR DESCRIPTION
- Create MusicAlbum class in  music_album.rb file.
- All MusicAlbum class properties visible in the diagram are defined and set up in the constructor method.

### Methods implemented:
#### can_be_archived?
  - It overrides the method from the parent class
  - Returns true if publish date is greater than 10 years AND if on_spotify equals true
  - otherwise, it returns false